### PR TITLE
Remove pandas from sample web page

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>SNOMED Dummy Data Viewer</title>
+  <link rel="stylesheet" href="https://pyscript.net/latest/pyscript.css" />
+  <script defer src="https://pyscript.net/latest/pyscript.js"></script>
+  <!-- duckdb-wasm JavaScript bundle -->
+  <script src="https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.23.1/dist/duckdb-browser.js"></script>
+</head>
+<body>
+  <h1>SNOMED Dummy Data Viewer</h1>
+  <div id="output"></div>
+  <py-config>
+packages = ["duckdb"]
+  </py-config>
+  <py-script output="output">
+import duckdb
+
+# Paths to dummy RF2 tables relative to this HTML file
+base = "data/rf2/SnomedCT_DummyRF2_PRODUCTION_20230101T000000Z/Snapshot/Terminology/"
+files = {
+    "Concept": base + "sct2_Concept_Snapshot_INT_20230101.txt",
+    "Description": base + "sct2_Description_Snapshot-en_INT_20230101.txt",
+    "TextDefinition": base + "sct2_TextDefinition_Snapshot-en_INT_20230101.txt",
+    "Relationship": base + "sct2_Relationship_Snapshot_INT_20230101.txt",
+}
+
+conn = duckdb.connect()
+for table, path in files.items():
+    conn.execute(f"CREATE TABLE {table} AS SELECT * FROM read_csv_auto('{path}', delim='\t')")
+
+for table in files.keys():
+    display(f"--- {table} ---")
+    df = conn.execute(f"SELECT * FROM {table}").df()
+    display(df)
+  </py-script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- refine `tests/index.html` to load RF2 tables with DuckDB's built-in CSV reader instead of pandas

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError for IProgress and extension installation error)*

------
https://chatgpt.com/codex/tasks/task_e_684c4c5f834083329fa4151016df1ef9